### PR TITLE
Refactor/feeling component

### DIFF
--- a/src/Components/Activities/Activities.js
+++ b/src/Components/Activities/Activities.js
@@ -1,9 +1,14 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import './Activities.css';
-import { Link } from 'react-router-dom';
+import { Link, useRouteMatch } from 'react-router-dom';
 
-const Activities = ({ activities, updateActivity }) => {
+const Activities = ({ activities, updateActivity, setFeeling }) => {
   const [currentActivityIndex, setCurrentActivityIndex] = useState(0);
+
+  const { params } = useRouteMatch('/what-should-you-do/:feeling');
+  useEffect(() => {
+    setFeeling(params.feeling);
+  }, [setFeeling, params.feeling])
 
   const nextActivity = () => {
     let nextIndex = currentActivityIndex + 1;

--- a/src/Components/Activities/Activities.js
+++ b/src/Components/Activities/Activities.js
@@ -28,7 +28,7 @@ const Activities = ({ activities, updateActivity, setFeeling }) => {
     <section className="activity-page">
       <div className="activity-card">
         {currentActivityIndex > 0 && <button onClick={() => prevActivity()}>←</button>}
-        <h2>{activities[currentActivityIndex].activity}</h2>
+        <h2>{activities[currentActivityIndex]?.activity}</h2>
         {currentActivityIndex < activities.length - 1 && <button onClick={() => nextActivity()}>→</button>}
       </div>
       <Link to="/why-are-you-feeling-that-way" className="go-button" onClick={() => selectActivity()}>Let's do it!</Link>

--- a/src/Components/App/App.js
+++ b/src/Components/App/App.js
@@ -48,6 +48,9 @@ const App = () => {
         <Route exact path='/how-you-felt/entry/:id' render={({ match }) => {
           const { id } = match.params;
           const journal = userLogs.find(log => log.entryId === parseInt(id));
+          if (!journal) {
+            return null;
+          }
           return <JournalEntry journal={journal}/>
         }}/>
         <Route exact path='/how-you-felt'><FeelingsLog logs={userLogs}/></Route>

--- a/src/Components/App/App.js
+++ b/src/Components/App/App.js
@@ -43,7 +43,9 @@ const App = () => {
       <Switch>
         <Route exact path='/'><Home /></Route>
         <Route exact path='/how-are-you-feeling'><Feelings setFeeling={setFeeling}/></Route>
-        <Route exact path='/what-should-you-do'><Activities activities={activities} updateActivity={updateActivity}/></Route>
+        <Route exact path={'/what-should-you-do/:feeling'}>
+          <Activities activities={activities} updateActivity={updateActivity} setFeeling={setFeeling}/>
+        </Route>
         <Route exact path='/why-are-you-feeling-that-way'><JournalPrompt /></Route>
         <Route exact path='/how-you-felt/entry/:id' render={({ match }) => {
           const { id } = match.params;

--- a/src/Components/App/App.js
+++ b/src/Components/App/App.js
@@ -2,6 +2,7 @@ import React, {useState, useEffect} from 'react';
 import { Route, NavLink, Switch } from 'react-router-dom';
 import activityData from '../../sampleData/activityData';
 import entryData from '../../sampleData/entryData';
+import feelingsData from '../Feelings/feelingsData';
 import Home from '../Home/Home';
 import Header from '../Header/Header';
 import Feelings from '../Feelings/Feelings';
@@ -24,14 +25,17 @@ const App = () => {
     setActivity(activity);
   }
 
+  const filterActivities = () => {
+    const feelingCategory = feelingsData
+      .find(({ associatedFeelings }) => associatedFeelings.includes(feeling))
+      ?.feeling.toLowerCase();
+    const filtered = activities.filter(act => act.feelings.includes(feelingCategory));
+    setFilteredActivities(filtered);
+  }
+
   useEffect(() => {
     filterActivities();
   }, [feeling]);
-
-  const filterActivities = () => {
-    const filtered = activities.filter(act => act.feelings.includes(feeling));
-    setFilteredActivities(filtered);
-  }
 
   useEffect(() => {
     setUserLogs(entryData);
@@ -44,7 +48,7 @@ const App = () => {
         <Route exact path='/'><Home /></Route>
         <Route exact path='/how-are-you-feeling'><Feelings setFeeling={setFeeling}/></Route>
         <Route exact path={'/what-should-you-do/:feeling'}>
-          <Activities activities={activities} updateActivity={updateActivity} setFeeling={setFeeling}/>
+          <Activities activities={filteredActivities} updateActivity={updateActivity} setFeeling={setFeeling}/>
         </Route>
         <Route exact path='/why-are-you-feeling-that-way'><JournalPrompt /></Route>
         <Route exact path='/how-you-felt/entry/:id' render={({ match }) => {

--- a/src/Components/Feelings/Feelings.js
+++ b/src/Components/Feelings/Feelings.js
@@ -3,11 +3,11 @@ import './Feelings.css';
 import feelingsData from './feelingsData';
 import { Link } from 'react-router-dom';
 
-const Feelings = ({ setFeeling }) => {
+const Feelings = () => {
 
   const feelingsLinks = feelingsData.map(feelingData => {
     return feelingData.associatedFeelings.map(feel => {
-      return <Link to={`/what-should-you-do/`} onClick={() => setFeeling(feel)} key={feel} className='feeling'>{feel}</Link>
+      return <Link to={`/what-should-you-do/${feel}`} key={feel} className='feeling'>{feel}</Link>
     })
   });
 

--- a/src/Components/Feelings/Feelings.js
+++ b/src/Components/Feelings/Feelings.js
@@ -1,40 +1,23 @@
 import React from 'react';
 import './Feelings.css';
+import feelingsData from './feelingsData';
 import { Link } from 'react-router-dom';
 
 const Feelings = ({ setFeeling }) => {
 
-  const selectFeeling = ({ target }) => {
-    setFeeling(target.classList[1]);
-  }
+  const feelingsLinks = feelingsData.map(feelingData => {
+    return feelingData.associatedFeelings.map(feel => {
+      return <Link to={`/what-should-you-do/`} onClick={() => setFeeling(feel)} key={feel} className='feeling'>{feel}</Link>
+    })
+  });
 
   return (
     <section className='feelings-page'>
       <h1>BEAM</h1>
       <h2 className='feelings-header'>How are you today?</h2>
-        <Link className='feelings-container' to='/what-should-you-do'>
-          <p className='feeling happy' onClick={selectFeeling}>Happy</p>
-          <p className='feeling happy' onClick={selectFeeling}>Content</p>
-          <p className='feeling happy' onClick={selectFeeling}>Optimistic</p>
-          <p className='feeling sad' onClick={selectFeeling}>Sad</p>
-          <p className='feeling sad' onClick={selectFeeling}>Lonely</p>
-          <p className='feeling sad' onClick={selectFeeling}>Depressed</p>
-          <p className='feeling surprised' onClick={selectFeeling}>Surpised</p>
-          <p className='feeling surprised' onClick={selectFeeling}>Confused</p>
-          <p className='feeling surprised' onClick={selectFeeling}>Excited</p>
-          <p className='feeling bad' onClick={selectFeeling}>Bad</p>
-          <p className='feeling bad' onClick={selectFeeling}>Stressed</p>
-          <p className='feeling bad' onClick={selectFeeling}>Tired</p>
-          <p className='feeling fearful' onClick={selectFeeling}>Fearful</p>
-          <p className='feeling fearful' onClick={selectFeeling}>Anxious</p>
-          <p className='feeling fearful' onClick={selectFeeling}>Insecure</p>
-          <p className='feeling angry' onClick={selectFeeling}>Angry</p>
-          <p className='feeling angry' onClick={selectFeeling}>Distant</p>
-          <p className='feeling angry' onClick={selectFeeling}>Frustrated</p>
-          <p className='feeling disguisted' onClick={selectFeeling}>Disguisted</p>
-          <p className='feeling disguisted' onClick={selectFeeling}>Disappointed</p>
-          <p className='feeling disguisted' onClick={selectFeeling}>Awful</p>
-        </Link>
+      <div className='feelings-container'>
+        {feelingsLinks}
+      </div>
     </section>
   );
 }

--- a/src/Components/Feelings/feelingsData.js
+++ b/src/Components/Feelings/feelingsData.js
@@ -1,0 +1,59 @@
+const feelings = [{
+    'feeling': 'Happy',
+    'associatedFeelings': [
+      'Happy',
+      'Content',
+      'Optimistic'
+    ]
+  },
+  {
+    'feeling': 'Sad',
+    'associatedFeelings': [
+      'Sad',
+      'Lonely',
+      'Depressed'
+    ]
+  },
+  {
+    'feeling': 'Surprised',
+    'associatedFeelings': [
+      'Surprised',
+      'Confused',
+      'Excited'
+    ]
+  },
+  {
+    'feeling': 'Bad',
+    'associatedFeelings': [
+      'Bad',
+      'Stressed',
+      'Tired'
+    ]
+  },
+  {
+    'feeling': 'Fearful',
+    'associatedFeelings': [
+      'Fearful',
+      'Anxious',
+      'Insecure'
+    ]
+  },
+  {
+    'feeling': 'Angry',
+    'associatedFeelings': [
+      'Angry',
+      'Distant',
+      'Frustrated'
+    ]
+  },
+  {
+    'feeling': 'Disgusted',
+    'associatedFeelings': [
+      'Disgusted',
+      'Disappointed',
+      'Awful'
+    ]
+  }
+];
+
+export default feelings;


### PR DESCRIPTION
### Files Changed:
- `App.js`
- `Feelings.js`
- `Activities.js`
- `feelingsData.js`

### What Has Changed: 
- This creates a feelings data file (that includes a feeling category and feelings associated with said category).
- This data is then mapped over to create a link for each feeling and populated in the `Feelings` component.
- This adds the actual feeling selected (not just the category) to the URL (part of state for a moment.
- `App`'s feeling state is getting set inside of Activities (instead of inside `Feelings`) - this allows user to refresh the page)!!
- This adds error handling so if a journal entry is not found, the app doesn't crash
- This updates the filtering logic in `App` (based on the actual feeling instead of the category) and then passes _only_ the `filteredActivities` rather than all activities to the `Activity` component (This works! I tested it)

### Notes: 
- I utilized the `useRouteMatch` hook. This allows you to access the `match` object *inside* the component _instead_ of in the parent component where it is being rendered.
- Not sure about the location of the feelings data.. should it live elsewhere?
- I think the `Activity `component should render a specific size instead of it depending on the length of the activity because it _feels_ a little glitchy (when it's loading) - refresh that page, you'll see what I mean.
- Let's not forget to add cursor pointer to the arrows on `Activity` - adding an issue now

### Closes: #12 
