### PR TITLE
refac: clean up controlled form in Journal Prompt component

### DIFF
--- a/src/Components/JournalPrompt/JournalPrompt.js
+++ b/src/Components/JournalPrompt/JournalPrompt.js
@@ -5,21 +5,12 @@ import './JournalPrompt.css';
 const JournalPrompt = ( {updateJournal} ) => {
   const [newEntry, setNewEntry] = useState('');
 
-  const updateEntry = () => {
-    const input = document.getElementById('journal-entry');
-    setNewEntry(input.value);
-  }
-
-  const submitEntry = () => {
-    updateJournal(newEntry);
-  }
-
   return (
     <div className="prompt-container">
       <form>
         <h2 className="prompt">Why are you feeling this way?</h2>
-        <textarea id="journal-entry" onChange={updateEntry}></textarea>
-        <Link to="/how-you-felt" className="uni-btn" onClick={submitEntry}>→</Link>
+        <textarea id="journal-entry" onChange={(event) => setNewEntry(event.target.value)}></textarea>
+        <Link to= "/how-you-felt" className="uni-btn" onClick={() => updateJournal(newEntry)}>→</Link>
       </form>
     </div>
   )


### PR DESCRIPTION
### Files Changed:

- JournalPrompt.js

### What Has Changed: 

This ended up to be pretty minor refactoring. Just used event targeting rather that selecting the DOM element so I could invoke the callback within the return rather than split it into the other functions.

### Notes: (includes questions, ideas for the future, anything you want to call out)

- When I initially wrote the code for this component I wrote the separate functions for the sake of clarity, but I think the direct invocation is okay in this situation because there isn't a lot of logic going on. But let me know if the initial structure made more sense to y'all.
- I was thinking about error handing again for this page, but then remembered we weren't going to make the user complete a journal entry. (correct me if I'm wrong here)
 - I was thinking we could conditionally render the next button so it would say 'skip journal entry' if the entry is empty and 'submit entry' or 'next' if the entry was completed for more clarity? Just an idea for later, let me know what ya think!

### Closes: (any issues that it closes)
